### PR TITLE
Improve MWIS speed through pivoting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /build/lib/openmht
 test/
 *.DS_Store
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /dist
 /openmht.egg-info
 /build/lib/openmht
+test/
+*.DS_Store

--- a/__main__.py
+++ b/__main__.py
@@ -1,4 +1,4 @@
-from .openmht import cli
+from openmht import cli
 
 
 def main():

--- a/openmht/cli.py
+++ b/openmht/cli.py
@@ -2,8 +2,8 @@
 """CLI"""
 
 from .mht import MHT
+from pathlib import Path
 
-import os
 import sys
 import argparse
 import time
@@ -122,11 +122,11 @@ def read_cli_parameters():
 
     # Verify CSV file formats
     try:
-        assert os.path.isfile(input_file), "Input file does not exist: {}".format(input_file)
-        assert os.path.isfile(param_file), "Parameter file does not exist: {}".format(param_file)
-        assert os.path.splitext(input_file)[-1].lower() == '.csv', "Input file is not CSV: {}".format(input_file)
-        assert os.path.splitext(output_file)[-1].lower() == '.csv', "Output file is not CSV: {}".format(output_file)
-        assert os.path.splitext(param_file)[-1].lower() == '.txt', "Parameter file is not TXT: {}".format(param_file)
+        assert Path(input_file).is_file(), f"Input file does not exist: {input_file}"
+        assert Path(param_file).is_file(), f"Parameter file does not exist: {param_file}"
+        assert Path(input_file).suffix == '.csv', f"Input file is not CSV: {input_file}"
+        assert Path(output_file).suffix == '.csv', f"Output file is not CSV: {output_file}"
+        assert Path(param_file).suffix == '.txt', f"Parameter file is not TXT: {param_file}"
 
     except AssertionError as e:
         print(e)
@@ -153,4 +153,4 @@ def read_cli_parameters():
     write_uv_csv(output_file, solution_coordinates)
     end = time.time()
     elapsed_seconds = end - start
-    logging.info("Elapsed time (seconds): {0:.3f}".format(elapsed_seconds))
+    logging.info(f"Elapsed time (seconds): {elapsed_seconds:.3f}")


### PR DESCRIPTION
Attempted to improve MWIS execution speed by:

1. using the Bron-Kerbosch (BK) algorithm with pivoting throughout recursion (it was switching to without pivoting after one recursive call).
2. Choosing the pivot point to maximize the size of `N(u)`, thus minimize the size of `P \ N(u)` and consequently the number of recursive branches.

Still very slow with larger number of branches `n`, but it turns out BK is `O(3^(n/3))`, so there's only so much I could expect.

On my system, the second frame executed in 35 minutes without changes, down to 2.5 minutes with changes.

Also added type hints where I was working and a couple of style updates. Note the import change in `__main__.py` was necessary to run on my system for debugging, but may not be correct for deployment, so please test that.